### PR TITLE
Fix for cool.io 1.1.0

### DIFF
--- a/lib/directory_watcher/coolio_scanner.rb
+++ b/lib/directory_watcher/coolio_scanner.rb
@@ -154,7 +154,7 @@ class DirectoryWatcher::CoolioScanner < ::DirectoryWatcher::Scanner
       @scanner = scanner
     end
 
-    def on_change
+    def on_change(prev, current)
       @scanner._on_change self
     end
 


### PR DESCRIPTION
Cool.io v1.1.0 passes previous and current filestats to the on_change
event.
